### PR TITLE
feat: Install dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "06:00"
-    timezone: Europe/Paris
-  open-pull-requests-limit: 5
-  target-branch: master
-  labels:
-    - dependencies
 - package-ecosystem: npm
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "06:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 5
+  target-branch: master
+  labels:
+    - dependencies
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "06:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 5
+  target-branch: master
+  labels:
+    - dependencies


### PR DESCRIPTION
Installation of [dependabot](https://dependabot.com/#how-it-works), that survey vendors

### Added
- `.github/dependabot.yml` to survey npm dependencies; /!\ I don't remember if dependabot is able create itself the label `dependencies`, maybe a manual action will be required [here](https://github.com/mishterk/wp-tailwindcss-theme-boilerplate/labels)