### PR TITLE
Remove hardcoded "en" language attribute and maximum viewport scale

### DIFF
--- a/templates/partials/document-open.php
+++ b/templates/partials/document-open.php
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en" class="no-js">
+<html <?php language_attributes(); ?> class="no-js">
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport"
-		      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+		      content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<title><?= wp_get_document_title() ?></title>
 		<script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');</script>


### PR DESCRIPTION
This PR replaces the hardcoded "en" value on the HTML attribute with WordPress' `lanaguage_attributes` function.

It also removes the maximum viewport scale which can interfere with A11Y and usability for users that need to be able to zoom in on pages.